### PR TITLE
[IOS] Github 로그인 서버 연동

### DIFF
--- a/ios/IssueTracker/IssueTracker/AppDelegate.swift
+++ b/ios/IssueTracker/IssueTracker/AppDelegate.swift
@@ -9,7 +9,7 @@ import UIKit
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
-
+    
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true

--- a/ios/IssueTracker/IssueTracker/Controllers/LoginViewController.swift
+++ b/ios/IssueTracker/IssueTracker/Controllers/LoginViewController.swift
@@ -8,8 +8,7 @@
 import UIKit
 
 protocol LoginViewControllerDelegate: class {
-    func addUserData()
-    func requestCode()
+    func requestCode(loginViewController: LoginViewController)
 }
 
 class LoginViewController: UIViewController {
@@ -28,6 +27,6 @@ class LoginViewController: UIViewController {
     }
     
     @IBAction func loginGitHub(_ sender: UIButton) {
-        delegate?.requestCode()
+        delegate?.requestCode(loginViewController: self)
     }
 }

--- a/ios/IssueTracker/IssueTracker/Controllers/MainViewController.swift
+++ b/ios/IssueTracker/IssueTracker/Controllers/MainViewController.swift
@@ -8,7 +8,6 @@
 import UIKit
 
 class MainViewController: UITabBarController {
-    var accessToken: String?
     var githubLogin: GithubLogin?
     
     override func viewDidLoad() {
@@ -27,7 +26,7 @@ class MainViewController: UITabBarController {
     }
     
     private func checkAccessToken() {
-        guard accessToken == nil else { return }
+        guard githubLogin?.token == nil else { return }
         let login = configureLoginViewController()
         login.delegate = self
         login.modalPresentationStyle = .fullScreen
@@ -37,14 +36,8 @@ class MainViewController: UITabBarController {
 
 extension MainViewController: LoginViewControllerDelegate {
     func requestCode(loginViewController: LoginViewController) {
-        githubLogin?.requestCode { result in
-            switch result {
-            case let .success(token):
-                self.accessToken = token
-                loginViewController.dismiss(animated: true, completion: nil)
-            case let .failure(error):
-                print("error: ", error)
-            }
+        githubLogin?.requestCode { 
+            loginViewController.dismiss(animated: true, completion: nil)
         }
     }
 }

--- a/ios/IssueTracker/IssueTracker/Controllers/MainViewController.swift
+++ b/ios/IssueTracker/IssueTracker/Controllers/MainViewController.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 class MainViewController: UITabBarController {
-    var userData: Any?
+    var accessToken: String?
     var githubLogin: GithubLogin?
     
     override func viewDidLoad() {
@@ -17,7 +17,7 @@ class MainViewController: UITabBarController {
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        checkUserData()
+        checkAccessToken()
     }
     
     private func configureLoginViewController() -> LoginViewController {
@@ -26,8 +26,8 @@ class MainViewController: UITabBarController {
         return login
     }
     
-    private func checkUserData() {
-        guard userData == nil else { return }
+    private func checkAccessToken() {
+        guard accessToken == nil else { return }
         let login = configureLoginViewController()
         login.delegate = self
         login.modalPresentationStyle = .fullScreen
@@ -36,11 +36,15 @@ class MainViewController: UITabBarController {
 }
 
 extension MainViewController: LoginViewControllerDelegate {
-    func requestCode() {
-        githubLogin?.requestCode()
-    }
-    
-    func addUserData() {
-        userData = "user"
+    func requestCode(loginViewController: LoginViewController) {
+        githubLogin?.requestCode { result in
+            switch result {
+            case let .success(token):
+                self.accessToken = token
+                loginViewController.dismiss(animated: true, completion: nil)
+            case let .failure(error):
+                print("error: ", error)
+            }
+        }
     }
 }

--- a/ios/IssueTracker/IssueTracker/Models/GithubLoginManager.swift
+++ b/ios/IssueTracker/IssueTracker/Models/GithubLoginManager.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import UIKit
-import Alamofire
 
 protocol GithubLogin {
     var token: String? { get }

--- a/ios/IssueTracker/IssueTracker/Models/GithubLoginManager.swift
+++ b/ios/IssueTracker/IssueTracker/Models/GithubLoginManager.swift
@@ -25,8 +25,6 @@ final class GithubLoginManager: GithubLogin {
         case haveNoAccessToken
     }
     
-    private let clientId = "e9eac94fb40d8f0685f0"
-    private let clientSecret = "ea55ceea6bf5da622dff960705be5e11fd8b88c2"
     var completionHandler: (() -> Void)?
     
     static let shared = GithubLoginManager()

--- a/ios/IssueTracker/IssueTracker/SceneDelegate.swift
+++ b/ios/IssueTracker/IssueTracker/SceneDelegate.swift
@@ -8,9 +8,9 @@
 import UIKit
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
-
+    
     var window: UIWindow?
-
+    
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
@@ -21,43 +21,37 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
     
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
-        if let url = URLContexts.first?.url {
-            if url.absoluteString.starts(with: "issuetracker://") {
-                if let code = url.absoluteString.split(separator: "=").last.map({ String($0) }) {
-                    GithubLoginManager.shared.requestAccessToken(with: code)
-                }
-            }
-        }
+        checkGithubResponse(openURLContexts: URLContexts)
     }
-
+    
     func sceneDidDisconnect(_ scene: UIScene) {
         // Called as the scene is being released by the system.
         // This occurs shortly after the scene enters the background, or when its session is discarded.
         // Release any resources associated with this scene that can be re-created the next time the scene connects.
         // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
     }
-
+    
     func sceneDidBecomeActive(_ scene: UIScene) {
         // Called when the scene has moved from an inactive state to an active state.
         // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
     }
-
+    
     func sceneWillResignActive(_ scene: UIScene) {
         // Called when the scene will move from an active state to an inactive state.
         // This may occur due to temporary interruptions (ex. an incoming phone call).
     }
-
+    
     func sceneWillEnterForeground(_ scene: UIScene) {
         // Called as the scene transitions from the background to the foreground.
         // Use this method to undo the changes made on entering the background.
     }
-
+    
     func sceneDidEnterBackground(_ scene: UIScene) {
         // Called as the scene transitions from the foreground to the background.
         // Use this method to save data, release shared resources, and store enough scene-specific state information
         // to restore the scene back to its current state.
     }
-
+    
 }
 
 extension SceneDelegate {
@@ -75,5 +69,14 @@ extension SceneDelegate: GithubLoginManagerDelegate {
     
     func open(_ url: URL) {
         UIApplication.shared.open(url)
+    }
+}
+
+extension SceneDelegate {
+    func checkGithubResponse(openURLContexts URLContexts: Set<UIOpenURLContext>) {
+        guard let url = URLContexts.first?.url else { return }
+        guard url.absoluteString.starts(with: "issuetracker://") else { return }
+        guard let code = url.absoluteString.split(separator: "=").last.map({ String($0) }) else { return }
+        GithubLoginManager.shared.requestAccessToken(with: code)
     }
 }

--- a/ios/IssueTracker/IssueTracker/SceneDelegate.swift
+++ b/ios/IssueTracker/IssueTracker/SceneDelegate.swift
@@ -75,8 +75,9 @@ extension SceneDelegate: GithubLoginManagerDelegate {
 extension SceneDelegate {
     func checkGithubResponse(openURLContexts URLContexts: Set<UIOpenURLContext>) {
         guard let url = URLContexts.first?.url else { return }
-        guard url.absoluteString.starts(with: "issuetracker://") else { return }
-        guard let code = url.absoluteString.split(separator: "=").last.map({ String($0) }) else { return }
-        GithubLoginManager.shared.requestAccessToken(with: code)
+        guard url.absoluteString.starts(with: "issuetracker://=") else { return }
+        guard let token = url.absoluteString.split(separator: "=").last.map({ String($0) }) else { return }
+        GithubLoginManager.shared.token = token
+        GithubLoginManager.shared.completionHandler?()
     }
 }


### PR DESCRIPTION
## 구현 내용
1. 서버와 연동해 Github 로그인 구현
   - 서버의 url을 이용해 Github 로그인페이지로 redirection
   - 서버는 app redirection url과 함께 토큰을 앱으로 전송
   - 받아온 토큰은 GithubLoginManager가 저장

