### PR TITLE
[Web] 이슈 생성 페이지에서 레이블 선택 기능 구현(일부 기능 누락), 기타 버그 수정

### DIFF
--- a/frontend/src/components/milestone/MilestoneTitle.js
+++ b/frontend/src/components/milestone/MilestoneTitle.js
@@ -51,8 +51,8 @@ const ClockImg = styled.img`
 const UpdateDateText = styled.p`
     margin: 0 auto;
 
-color: gray;
-font-weight: lighter;
+    color: gray;
+    font-weight: lighter;
 `;
 
 const getElapsedTime = (date) => {

--- a/frontend/src/contexts/milestone.js
+++ b/frontend/src/contexts/milestone.js
@@ -29,7 +29,7 @@ const MilestoneProvider = ({ children }) => {
             try {
                 setLoading(true);
 
-                const result = await axios.get('http://localhost:3000/api/milestone');
+                const result = await axios.get('http://127.0.0.1:3000/api/milestone', { withCredentials: true });
 
                 dispatch({type: 'set', list: result.data});
             } catch (error) {

--- a/frontend/src/contexts/userList.js
+++ b/frontend/src/contexts/userList.js
@@ -13,7 +13,7 @@ const UserListProvider = ({ children }) => {
                 setLoading(true);
                 setUser(null);
 
-                const result = await axios.get('http://api.hoyoung.me/api/user');
+                const result = await axios.get('http://127.0.0.1:3000/api/user', { withCredentials: true });
 
                 setUser(result.data.data);
             } catch (error) {

--- a/frontend/src/organisms/issue/IssueAddingMain.js
+++ b/frontend/src/organisms/issue/IssueAddingMain.js
@@ -5,12 +5,14 @@ import IssueInputTitle from '../../components/Issue/IssueInputTitle';
 import IssueInputButtons from '../../components/Issue/IssueInputButtons';
 
 const MainLayout = styled.div`
+    flex: 0.7;
+
     width: 60%;
     
     margin: 0 auto;
-    margin-right: 30px;
-    margin-left: 7%;
-
+    margin-left: 3%;
+    margin-right: 3%;
+    
     border: 1px solid #e1e4e8;
     border-radius: 6px;
 `;


### PR DESCRIPTION
1. axios를 사용할 때 withCredentials 옵션이 빠진 것들을 수정.
2. 기타 스타일 수정(크기, 간격 등)
3. 레이블 목록을 보고 선택한 레이블이 지정되는 기능을 구현 -> 실제 데이터베이스에 저장하는 기능은 아직 구현되지 않았다.